### PR TITLE
Complete proportional font support using textmetrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+An OpenSCAD library (`text_on.scad`) for placing 3D text on geometric surfaces. The entire library is a single `.scad` file. There is no build system, package manager, or test runner.
+
+## Development Commands
+
+**Render example PNGs** (requires OpenSCAD binary at the path in the script):
+```bash
+cd examples && bash make_example_pngs.sh
+```
+
+**Render a single example** (adjust camera/path as needed):
+```bash
+openscad -o examples/text_on_cylinder.scad.png --enable=text --camera=0,0,0,75,0,25,150 examples/text_on_cylinder.scad
+```
+
+**Create a release zip:**
+```bash
+cd development && bash make_release_zip.sh
+```
+
+**Usage in a project** — copy `text_on.scad` next to the user's file and add:
+```scad
+use <text_on.scad>
+```
+
+## Architecture
+
+All public modules eventually call `text_extrude()`, which wraps OpenSCAD's `linear_extrude()`+`text()`. The call hierarchy is:
+
+- `text_on_sphere()` → `__internal_text_on_sphere_helper()` → `text_extrude()`
+- `text_on_cylinder()` → `text_on_circle()` (top/bottom face) or `__internal_text_on_cylinder_side()` → `text_extrude()`
+- `text_on_circle()` → `text_extrude()` (one call per character)
+- `text_on_cube()` → `text_extrude()` (single call with full string)
+
+Modules prefixed with `__internal_` are private helpers; do not call them directly.
+
+### Textmetrics
+
+The library detects OpenSCAD version at runtime:
+```scad
+internal_tm_avail = version()[0] > 2021;
+```
+
+When `internal_tm_avail` is true, OpenSCAD's `textmetrics()` built-in is used for precise proportional-font character positioning. When false, the legacy `internal_space_fudge = 0.80` approximation is used. Every character-positioning calculation has both branches (`tm_*` functions for textmetrics, plain functions for legacy).
+
+### Key Global State
+
+- `debug = true` — left enabled; `echo()` calls throughout are commented out in most places
+- `default_font = "Liberation Mono"` — monospace default; proportional fonts work via textmetrics
+- `default_buffer_width = 0` — letter thickening via `offset()` before extrusion; exposed as `buffer_width` param
+
+### Coordinate Conventions
+
+- All faux-objects are treated as `center=true`; the `cylinder_center` param handles the exception
+- `eastwest` rotates around Z-axis; `northsouth` tilts on sphere; `updown` shifts vertically on cylinder/cube
+- `rotate` parameter spirals text helically on curved surfaces (not simple 2D rotation)
+- `halign`/`valign` are accepted but **not supported** on sphere/cylinder/circle — a warning is echoed
+
+### Character-by-Character Rendering
+
+`text_on_sphere`, `text_on_circle`, and `__internal_text_on_cylinder_side` render one character at a time in a `for` loop, computing each character's angular position on the surface. `text_on_cube` passes the full string to `text_extrude()` directly.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ text_on_OpenSCAD
 A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.
 
 Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported. The text module is still an experimental feature in newer releases and must be enabled at run time (--enable=text).
-Work with proportional fonts currently requires a deveopment release of OpenSCAD 2022.x.x or later because that's when the `textmetrics()` call was added.  My testing has been done with OpenSCAD 2026.02.04.
+Work with proportional fonts currently requires a [deveopment release](https://openscad.org/downloads.html#snapshots) of OpenSCAD 2022.x.x or later because that's when the `textmetrics()` call was added.  My testing has been done with OpenSCAD 2026.02.04 on MacOS 26.x on an Apple silicon chip.
 
 This is a rewrite and extension of the great write.scad (v3 from http://www.thingiverse.com/thing:16193) to use the new OpenSCAD internal text() primitive.
 * All credit to Harlan Martin (harlan@sutlog.com) for his great effort on the original.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ text_on_OpenSCAD
 A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.
 
 Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported. The text module is still an experimental feature in newer releases and must be enabled at run time (--enable=text).
-Work with proportional fonts currently requires a deveopment release of OpenSCAD 2022.x.x or later (My testing is with OpenSCAD 2026.02.04) because that's when the `textmetrics()` call was added.
+Work with proportional fonts currently requires a deveopment release of OpenSCAD 2022.x.x or later because that's when the `textmetrics()` call was added.  My testing has been done with OpenSCAD 2026.02.04.
 
 This is a rewrite and extension of the great write.scad (v3 from http://www.thingiverse.com/thing:16193) to use the new OpenSCAD internal text() primitive.
 * All credit to Harlan Martin (harlan@sutlog.com) for his great effort on the original.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ text_on_OpenSCAD
 A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.
 
 Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported. The text module is still an experimental feature in newer releases and must be enabled at run time (--enable=text).
-
+Work with proportional fonts currently requires a deveopment release of OpenSCAD 2022.x.x or later (My testing is with OpenSCAD 2026.02.04) because that's when the `textmetrics()` call was added.
 
 This is a rewrite and extension of the great write.scad (v3 from http://www.thingiverse.com/thing:16193) to use the new OpenSCAD internal text() primitive.
 * All credit to Harlan Martin (harlan@sutlog.com) for his great effort on the original.

--- a/README.md
+++ b/README.md
@@ -97,5 +97,7 @@ text_extrude.scad
 
 ## Development
 
-Please fork from at https://github.com/brodykenrick/text_on_OpenSCAD and fix any bugs or add any features and send a pull request.
+This repo was forked from https://github.com/brodykenrick/text_on_OpenSCAD because it hasn't been updated recently.
+
+Please fork from https://github.com/pneumaticdeath/text_on_OpenSCAD and fix any bugs or add any features and send a pull request.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ They also expose the arguments of the text() primitive:
 * script
 * halign -- left, right or center
 * valign -- baseline, bottom, top or center
+* roof -- use roof extrude instead of linear extrude
 
 And additional arguments:
 * extrusion_height //i.e. how far it sits proud

--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 text_on_OpenSCAD
 ================
 
-A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.
+A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.  This functionality has
+larger been [made obsolete by the BOSL2 library](https://github.com/BelfrySCAD/BOSL2/wiki/shapes3d.scad#module-text3d), but in case you don't want
+the size and complexity of that library, or prefer the simpler method calls of this library, I will keep text_on_OpenSCAD maintained for the time being.
 
-Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported. The text module is still an experimental feature in newer releases and must be enabled at run time (--enable=text).
-Work with proportional fonts currently requires a [deveopment release](https://openscad.org/downloads.html#snapshots) of OpenSCAD 2022.x.x or later because that's when the `textmetrics()` call was added.  My testing has been done with OpenSCAD 2026.02.04 on MacOS 26.x on an Apple silicon chip.
+Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported.
+[Deveopment releases](https://openscad.org/downloads.html#snapshots) of OpenSCAD 2022.x.x or later allows for proportional font support.  My testing
+has been done with OpenSCAD 2026.02.04 on MacOS 26.x on an Apple silicon chip.
+
+## History 
+
+[Mitch Patenaude](mailto:mitch@mitchpatenaude.net) took over development and support of this library in March 2026.
 
 This is a rewrite and extension of the great write.scad (v3 from http://www.thingiverse.com/thing:16193) to use the new OpenSCAD internal text() primitive.
 * All credit to Harlan Martin (harlan@sutlog.com) for his great effort on the original.
 * Great thanks to @t-paul (and the OpenSCAD dev team) on adding the new text() primitive giving us other fonts.
+
+## Overview
 
 Functions are provided for putting text on:
 * Spheres

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ text_on_OpenSCAD
 ================
 
 A library for putting customised "text on" 3D shapes in OpenSCAD with changeable fonts, languages/scripts, text direction.  This functionality has
-larger been [made obsolete by the BOSL2 library](https://github.com/BelfrySCAD/BOSL2/wiki/shapes3d.scad#module-text3d), but in case you don't want
+largely been [made obsolete by the BOSL2 library](https://github.com/BelfrySCAD/BOSL2/wiki/shapes3d.scad#module-text3d), but in case you don't want
 the size and complexity of that library, or prefer the simpler method calls of this library, I will keep text_on_OpenSCAD maintained for the time being.
 
 Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ larger been [made obsolete by the BOSL2 library](https://github.com/BelfrySCAD/B
 the size and complexity of that library, or prefer the simpler method calls of this library, I will keep text_on_OpenSCAD maintained for the time being.
 
 Only works with OpenSCAD v 2014.xx and later -- where text() module is added and unicode text is supported.
-[Deveopment releases](https://openscad.org/downloads.html#snapshots) of OpenSCAD 2022.x.x or later allows for proportional font support.  My testing
+[Deveopment releases](https://openscad.org/downloads.html#snapshots) of OpenSCAD 2022.x.x or later allow for proportional font support.  My testing
 has been done with OpenSCAD 2026.02.04 on MacOS 26.x on an Apple silicon chip.
 
 ## History 

--- a/text_on.scad
+++ b/text_on.scad
@@ -85,15 +85,30 @@ internal_pi2 = internal_pi * 2;
 // Internal values - You might want to play with these if you are using a proportional font
 internal_space_fudge = 0.80; // Fudge for working out lengths (widths) of strings
 
+// Do we have textmetrics available
+internal_tm_avail = version()[0] > 2021;
+
+echo(str("Using major version ", version()[0]));
+if (internal_tm_avail) {
+    echo("Using textmetrics");
+}
+
 debug = true;
 
 // ---- Helper Functions ----
+// Simple substr implementation
+function substr(string, f, l) = (l > 0) ? chr([for(i = [f:f+l-1]) ord(string[i])]) : "";
+
 // String width (length from left to right or RTL) in OpenSCAD units
 // NOTE: These are innacurate because we don't know the real spacing of the chars and so have to approximate
 // They work for monospaced (fixed-width) fonts well
 function width_of_text_char(size, spacing) = size * internal_space_fudge * spacing;
 function width_of_text_string_num_length(length, size, spacing) = width_of_text_char(size, spacing) * length;
 function width_of_text_string(t, size, spacing) = width_of_text_string_num_length(len(t), size, spacing);
+
+function tm_width_of_text_char(c, size, font, spacing) = textmetrics(c, size=size, font=font).advance[0] * spacing;
+function tm_width_of_partial_text_string(t, sublength, size, font, spacing) = textmetrics(substr(t, 0, sublength), size=size, font=font).advance[0] * spacing;
+function tm_width_of_text_string(t, size, font, spacing) = textmetrics(t, size=size, font=font).advance[0] * spacing;
 
 function cylinder_center_adjusted_top(height, center) = (center == true) ? height / 2 : height;
 function cylinder_center_adjusted_bottom(height, center) = (center == true) ? height / 2 : 0;
@@ -102,13 +117,27 @@ function cylinder_center_adjusted_bottom(height, center) = (center == true) ? he
 //Angle that measures width of letters on perimeter of a circle (and sphere and cylinder)
 function rotation_for_character(size, spacing, r, rotate = 0) = (width_of_text_char( size, spacing ) / (internal_pi2 * r)) * 360 * (1 - abs(rotate) / 90);
 
+function tm_rotation_for_partial_string(t, pos, size, font, spacing, r, rotate = 0) = (tm_width_of_partial_text_string(t, pos, size, font, spacing) / (internal_pi2 * r)) * 360 * (1 - abs(rotate) / 90);
+
+// Angle to the visual center of character l: advance of chars 0..l-1 plus half advance of char l.
+// Using this (instead of just advance(0..l-1)) with halign="center" renders each character flush
+// against its neighbours regardless of proportional width, just as in normal left-aligned text.
+function tm_rotation_to_char_center(t, l, size, font, spacing, r) =
+    (tm_width_of_partial_text_string(t, l, size, font, spacing) + tm_width_of_text_char(t[l], size, font, spacing) / 2) / (internal_pi2 * r) * 360;
 
 //Rotate 1/2 width of text if centering    
 //One less -- if we have a single char we are already centred..
 function rotation_for_center_text_string(t, size, spacing, r, rotate, center) = (center) ? (width_of_text_string_num_length(len(t) - 1, size, spacing) / 2 / (internal_pi2 * r) * 360) : 0;
 
+// With center-based positioning (tm_rotation_to_char_center), the string spans
+// [advance(0)/2 .. advance(0..n-1) - advance(n-1)/2], so advance(0..n-1)/2 is the best
+// simple approximation for the visual midpoint.
+function tm_rotation_for_center_text_string(t, size, font, spacing, r, rotate, center) = (center) ? (tm_width_of_text_string(t, size, font, spacing) / 2 / (internal_pi2 * r) * 360) : 0;
+
 //Rotate according to rotate and if centred text also 1/2 width of text
 function rotation_for_center_text_string_and_rotate(t, size, spacing,r,rotate,center) = ((center) ? (width_of_text_string(t, size, spacing) / 2 / (internal_pi2 * r) * 360) : 1) * (1 - abs(rotate) / 90);
+
+function tm_rotation_for_center_text_string_and_rotate(t, size, font, spacing, r, rotate, center) = ((center) ? (tm_width_of_text_string(t, size, font, spacing) / 2 / (internal_pi2 * r) * 360) : 1) * (1 - abs(rotate) / 90);
 
 
 //---- Text on Object Functions ----
@@ -185,7 +214,9 @@ module text_on_cylinder(t = default_t,
         }
         //Work on the side
         locn_offset_vec = (cylinder_center == true) ? [0, 0, 0] : [0, 0, h / 2]; 
-        rotate(-rtl_sign * rotation_for_center_text_string_and_rotate(t, size, spacing, r, rotate, center), [0, 0, 1])
+        rotate(-rtl_sign * (internal_tm_avail
+                ? tm_rotation_for_center_text_string_and_rotate(t, size, font, spacing, r, rotate, center)
+                : rotation_for_center_text_string_and_rotate(t, size, spacing, r, rotate, center)), [0, 0, 1])
         translate(locn_vec + locn_offset_vec)
         __internal_text_on_cylinder_side(t,
                 locn_vec,
@@ -247,13 +278,16 @@ module text_on_circle(t = default_t,
     rtl_sign = (direction == "rtl") ? -1 : 1;
     ttb_btt_inaction = (direction == "ttb" || direction == "btt") ? 0 : 1;
     rotate_z_outer = -rotate + ccw_sign * eastwest;
-    rotate_z_inner = -rtl_sign * ccw_sign * ttb_btt_inaction * rotation_for_center_text_string(t, size, spacing, r-middle, rotate, center);
+    rotate_z_inner = -rtl_sign * ccw_sign * ttb_btt_inaction * (internal_tm_avail ? tm_rotation_for_center_text_string(t, size, font, spacing, r-middle, rotate, center)
+										  : rotation_for_center_text_string(t, size, spacing, r-middle, rotate, center));
     rotate(rotate_z_outer, [0, 0, 1] )
     rotate(rotate_z_inner, [0, 0, 1] )
     translate(locn_vec)
     for(l = [0 : len(t) - 1]) {
         //TTB/BTT means no per letter rotation
-        rotate_z_inner2 = -ccw_sign * 90 + ttb_btt_inaction * rtl_sign * ccw_sign * l * rotation_for_character(size, spacing, r - middle, rotate = 0);   //Bottom out=-270+r
+        rotate_z_inner2 = -ccw_sign * 90 + (
+		internal_tm_avail ? ttb_btt_inaction * rtl_sign * ccw_sign * tm_rotation_to_char_center(t, l, size, font, spacing, r - middle)
+				  : ttb_btt_inaction * rtl_sign * ccw_sign * l * rotation_for_character(size, spacing, r - middle, rotate = 0));   //Bottom out=-270+r
         //TTB means we go toward center, BTT means away
         vert_x_offset = (direction == "ttb" || direction == "btt") ? (l * size * ((direction == "btt") ? -1 : 1)) : 0;
         rotate(rotate_z_inner2, [0, 0, 1])
@@ -287,6 +321,8 @@ module __internal_text_on_cylinder_side(t = default_t,
                       r2,
                       h,
                       cylinder_center,
+                      updown = default_cylinder_updown,
+                      eastwest = default_circle_eastwest,
                       
                       //All objects
                       extrusion_height = default_extrusion_height,
@@ -353,20 +389,29 @@ module __internal_text_on_cylinder_side(t = default_t,
     rotate(eastwest, [0, 0, 1])
     for(l = [0 : len(t) - 1]) {
         //TODO: TTB and BTT need to have a different concept of path/length than this for RTL/LTR
+        length_to_center_of_char = (internal_tm_avail ? tm_width_of_partial_text_string(t, l, size, font, spacing) + tm_width_of_text_char(t[l], size, font, spacing) / 2
            //width_of_... is half a char too long -- add 0.5 (counting from zero)
-        length_to_center_of_char = width_of_text_string_num_length(l + 0.5, size, spacing);
+	                                              : width_of_text_string_num_length(l + 0.5, size, spacing));
         radius_here = calc_radius_at_length(rr1, rr2, h, length_to_center_of_char, rotate, updown);
         //Rotating into position and tangentially to surface -- Don't rotate per character for ttb/btt
         //-90 is to get centering at origin
-        rotate_z_inner = -90 + rtl_sign * rotation_for_character(size, spacing, radius_here, rotate) * ((ddirection == "ttb" || ddirection== "btt") ?  0 : l);
+        rotate_z_inner = -90 + rtl_sign * ((ddirection == "ttb" || ddirection == "btt") ? 0
+            : (internal_tm_avail
+                ? (tm_width_of_partial_text_string(t, l, size, font, spacing) + tm_width_of_text_char(t[l], size, font, spacing) / 2) / (internal_pi2 * radius_here) * 360
+                : rotation_for_character(size, spacing, radius_here, rotate) * l));
         rotate(rotate_z_inner, [0, 0, 1]) {
             //Positioning - based on (somewhat innacurate) string length
             //Offset per character to go up/down the side in ttb/btt -- TTB down, BTT up
             vert_z_char_offset = (ddirection == "ttb" || ddirection == "btt") ?  (l * size * ((ddirection == "ttb") ? -1 : 1 )) :  0 ;
             //Only if RTL/LTR and if center -- center the text (starts off in a more visually appealing location)
-            vert_z_half_text_offset_tmp = (len(t) -1) / 2 * (rotate / 90 * wid);
+            vert_z_half_text_offset_tmp = (internal_tm_avail
+                ? tm_width_of_text_string(t, size, font, spacing) / 2
+                : (len(t) - 1) / 2 * wid) * (rotate / 90);
             vert_z_half_text_offset = ((ddirection == "ttb" || ddirection == "btt") || (ccenter == false)) ? 0 : vert_z_half_text_offset_tmp;
-            translate([ radius_here , 0, vert_z_char_offset - l * (rotate / 90 * wid) + vert_z_half_text_offset])
+            vert_z_char_spiral = internal_tm_avail
+                ? (tm_width_of_partial_text_string(t, l, size, font, spacing) + tm_width_of_text_char(t[l], size, font, spacing) / 2) * (rotate / 90)
+                : l * (rotate / 90 * wid);
+            translate([ radius_here , 0, vert_z_char_offset - vert_z_char_spiral + vert_z_half_text_offset])
 
             //Flip to tangent on the sloping side (without respecting rotation impact on the tangent -- rotate seems a little off. TODO: Investigate).
             rotate(atan((rr2 - rr1) /h), [0, 1, 0])
@@ -439,7 +484,9 @@ module text_on_sphere(t = default_t,
     rotate(spin, [0, 1, 0]) {
         //This tries to center the text (for RTL text).
         ttb_btt_inaction = (direction == "ttb" || direction == "btt") ? 0 : 1;
-        rotate(-rtl_sign * ttb_btt_inaction * rotation_for_center_text_string(t, size, spacing, rr, rotate, center), [0, 0, 1]) {
+        rotate(-rtl_sign * ttb_btt_inaction * (internal_tm_avail
+                ? tm_rotation_for_center_text_string(t, size, font, spacing, rr, rotate, center)
+                : rotation_for_center_text_string(t, size, spacing, rr, rotate, center)), [0, 0, 1]) {
             translate(locn_vec)
             if (rounded == false) {
                 __internal_text_on_sphere_helper(t = t,
@@ -493,6 +540,7 @@ module __internal_text_on_sphere_helper(t = default_t,
                       //All objects
                       extrusion_height = default_extrusion_height,
                       center = default_center,
+                      rotate = default_rotate,
                       scale = default_scale,
                       //All objects -- arguments as for text()
                       font = undef,
@@ -509,7 +557,9 @@ module __internal_text_on_sphere_helper(t = default_t,
     ttb_btt_action = (direction == "ttb" || direction == "btt") ? 1 : 0;
     
     for(l = [0 : len(t) - 1]) {
-        rotate_z_inner = -90 + rtl_sign * ttb_btt_inaction * l * rotation_for_character(size, spacing, r, 0);
+        rotate_z_inner = -90 + rtl_sign * ttb_btt_inaction * (internal_tm_avail
+            ? tm_rotation_to_char_center(t, l, size, font, spacing, r)
+            : l * rotation_for_character(size, spacing, r, 0));
         translate_sign = (direction == "ttb" || direction == "btt") ? ((direction == "btt") ? 1 : -1)  : 0 ;
         //translate_effect = (direction=="ttb" || direction=="btt") ? 1  :  0 ;
         //Translate letter to be located on the sphere in up/down direction when we are doing TTB and BTT

--- a/text_on.scad
+++ b/text_on.scad
@@ -25,6 +25,7 @@ All modules also take the additional arguments:
 extrusion_height = depth of the letter, i.e. how far it sits proud
 rotate
 center //center the text at the location it is being written (NOT that the object is centered)
+roof Use roof instead of linear_extrude
 
 ALL faux-objects that the text is applied to have center=true
 TODO: object_center=true/false (already done for cylinder)
@@ -58,6 +59,7 @@ default_center = true; //Text-centering
 default_scale = [1,1,1];
 default_extrusion_height = 2; //mm letter extrusion height
 default_buffer_width = 0; //mm of buffer (thickening in all directions) to add to each letter
+default_roof = false;
 
 //Defaults for Cube
 default_cube_face = "front"; // default face (top,bottom,left,right,back,front)
@@ -172,7 +174,8 @@ module text_on_cylinder(t = default_t,
                         valign = undef,
                         language = undef,
                         script = undef,
-                        spacing = default_spacing) {
+                        spacing = default_spacing,
+                        roof = default_roof) {
 
 //    echo (str("text_on_cylinder:There are " ,len(t) ," letters in t" , t));
 //    echo (str("text_on_cylinder:","h" , h));
@@ -205,7 +208,8 @@ module text_on_cylinder(t = default_t,
                 rotate = rotate,
                 eastwest = eastwest,
                 middle = middle,
-                ccw = ccw);
+                ccw = ccw,
+                roof = roof);
     } else {
         if((middle != undef) && (middle != default_circle_middle)) {
             //TODO: Which others?
@@ -238,7 +242,8 @@ module text_on_cylinder(t = default_t,
                 rotate = rotate,
                 face = face,
                 updown = updown,
-                eastwest = eastwest);
+                eastwest = eastwest,
+                roof = roof);
     }
 }
 
@@ -265,7 +270,8 @@ module text_on_circle(t = default_t,
                       language = undef,
                       script = undef,
                       spacing = default_spacing,
-                      buffer_width = default_buffer_width) {
+                      buffer_width = default_buffer_width,
+                      roof = default_roof) {
 //    echo (str("text_on_circle:","There are " ,len(t) ," letters in t" , t));
 //    echo (str("text_on_circle:","rotate=" , rotate));
 //    echo (str("text_on_circle:","eastwest=" , eastwest));
@@ -305,7 +311,8 @@ module text_on_circle(t = default_t,
                 halign = halign,
                 valign = valign,
                 extrusion_height = extrusion_height,
-                buffer_width = buffer_width);
+                buffer_width = buffer_width,
+                roof =roof);
     }
 }
 
@@ -338,7 +345,8 @@ module __internal_text_on_cylinder_side(t = default_t,
                       language = undef,
                       script = undef,
                       spacing = default_spacing,
-                      buffer_width = default_buffer_width) {
+                      buffer_width = default_buffer_width,
+                      roof = default_roof) {
 //    echo (str("__internal_text_on_cylinder_side:There are " ,len(t) ," letters in t" , t));
 //    echo (str("__internal_text_on_cylinder_side:","h=" , h));
 //    echo (str("__internal_text_on_cylinder_side:","r=" , r));
@@ -434,7 +442,8 @@ module __internal_text_on_cylinder_side(t = default_t,
                     halign = "center", //This can be relaxed eventually
                     valign = "baseline", //Need this to keep all letters on the same line (could also support top -- otherw will make
                     extrusion_height = extrusion_height,
-                    buffer_width = buffer_width);
+                    buffer_width = buffer_width,
+                    roof = roof);
         }
     }
 }
@@ -463,7 +472,8 @@ module text_on_sphere(t = default_t,
                       valign = undef, //Not supported - only here to enable a warning
                       language = undef,
                       script = undef,
-                      spacing = default_spacing) {
+                      spacing = default_spacing,
+                      roof = default_roof) {
     //echo ("text_on_sphere:There are " ,len(t) ," letters in t" , t);
 
     if((halign != undef) || (halign != undef)) {
@@ -502,7 +512,8 @@ module text_on_sphere(t = default_t,
                         script = script,
                         halign = halign,
                         valign = valign,
-                        extrusion_height = extrusion_height);
+                        extrusion_height = extrusion_height,
+                        roof = roof);
             } else {
                 //If rounding then clip the text inside an inner sphere and outer sphere
                 intersection() {
@@ -519,7 +530,8 @@ module text_on_sphere(t = default_t,
                             script = script,
                             halign = halign,
                             valign = valign,
-                            extrusion_height = extrusion_height * 2); //Make it proud to clip it off.
+                            extrusion_height = extrusion_height * 2,
+                            roof = roof); //Make it proud to clip it off.
                     //Shell - bounding inner and outer
                     difference() { //rounded outside
                         sphere(rr + extrusion_height);
@@ -551,7 +563,8 @@ module __internal_text_on_sphere_helper(t = default_t,
                       language = undef,
                       script = undef,
                       spacing = default_spacing,
-                      buffer_width = default_buffer_width) {
+                      buffer_width = default_buffer_width,
+                      roof = default_roof) {
     rtl_sign = (direction == "rtl") ? -1 : 1;
     ttb_btt_inaction = (direction == "ttb" || direction == "btt") ? 0 : 1;
     ttb_btt_action = (direction == "ttb" || direction == "btt") ? 1 : 0;
@@ -586,7 +599,8 @@ module __internal_text_on_sphere_helper(t = default_t,
                 halign = "center", //This can be relaxed eventually
                 valign = "baseline", //Need this to keep all letters on the same line (could also support top -- otherw will make wonky letters)
                 extrusion_height = extrusion_height,
-                buffer_width = buffer_width);
+                buffer_width = buffer_width,
+                roof = roof);
     }
 }
 
@@ -617,7 +631,8 @@ module text_on_cube(  t = default_t,
                       language = undef,
                       script = undef,
                       spacing = default_spacing,
-                      buffer_width = default_buffer_width) {
+                      buffer_width = default_buffer_width,
+                      roof = default_roof) {
     //echo (str("text_on_cube:","There are " ,len(t) ," letters in t" , t));
     //echo (str("text_on_cube:","cube_size" , cube_size));
     
@@ -653,7 +668,8 @@ module text_on_cube(  t = default_t,
             halign = halign,
             valign = valign,
             extrusion_height = extrusion_height,
-            buffer_width = buffer_width );
+            buffer_width = buffer_width,
+            roof = roof);
 }
 
 function default_if_undef(val, default_val) = (val != undef) ? val : default_val;
@@ -675,7 +691,8 @@ module text_extrude( t = default_t,
                      language = undef,
                      script = undef,
                      spacing = default_spacing,
-                     buffer_width = default_buffer_width) {
+                     buffer_width = default_buffer_width,
+                     roof = default_roof) {
     //echo (str("text_extrude:","There are " ,len(t) ," letters in text" , t));
     //echo (str("text_extrude:","extrusion_height=" , extrusion_height));
     
@@ -701,17 +718,32 @@ module text_extrude( t = default_t,
     
     scale(scale)
     rotate(rotate, [0, 0, -1]) //TODO: Do we want to make this so that the entire vector can be set?
-    linear_extrude(height = extrusion_height, convexity = 10, center = extrusion_center)
-    offset(delta = buffer_width)
-    text(text = t,
-            size = size,
-            $fn = 40,
-            font = font,
-            direction = direction,
-            spacing = spacing,
-            halign = halign,
-            valign = valign,
-            language = language,
-            script = script);
-}
+    if (!roof) {
+        linear_extrude(height = extrusion_height, convexity = 10, center = extrusion_center)
+        offset(delta = buffer_width)
+        text(text = t,
+                size = size,
+                $fn = 40,
+                font = font,
+                direction = direction,
+                spacing = spacing,
+                halign = halign,
+                valign = valign,
+                language = language,
+                script = script);
+    } else {
+        roof(convexity = 10)
+        offset(delta = buffer_width)
+        text(text = t,
+                size = size,
+                $fn = 40,
+                font = font,
+                direction = direction,
+                spacing = spacing,
+                halign = halign,
+                valign = valign,
+                language = language,
+                script = script);
 
+    }
+}


### PR DESCRIPTION
Development versions of OpenSCAD support a textmetrics call that will allow for proper proportional font spacing.

This was development in concert with claude code.